### PR TITLE
team_name was never used, causing failure for manually entered teams

### DIFF
--- a/parroter.py
+++ b/parroter.py
@@ -157,7 +157,7 @@ class EmSlackPartyParroter(object):
 
         # Prompt user for missing args
         if not args.team:
-            args.team_name = raw_input('Slack Team: ').strip()
+            args.team = raw_input('Slack Team: ').strip()
         if not args.email:
             args.email = raw_input('Slack Email: ').strip()
         if not args.password:


### PR DESCRIPTION
args.team_name != args.team, thus a team_url of https://None.slack.com was attempted for manually entered team names. I wonder if that team actually exists? Regardless is not what we're looking for.